### PR TITLE
Added use of URL params for keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ values that populate it. We do this by defining two core concepts the Data Spec 
 to define all of the fields that should be generated for a record. The Data Spec does not care about the structure that the
 data will populate. A single Data Spec could be used to generate JSON, XML, or a csv file. Each field in the Data Spec has its own
 Field Spec that defines how the values for it should be created. There are a variety of core field types that are used to generate
-the data for each field.  Where the built in types are not sufficient, there is an easy way to create custom types and handlers for
+the data for each field.  Where the built-in types are not sufficient, there is an easy way to create custom types and handlers for
 them. The tool supports templating using the [Jinja2](https://pypi.org/project/Jinja2/) templating engine format.
 
 ## Build
@@ -50,13 +50,13 @@ should be joined. Below is an example Data Spec for creating email addresses.
       "type": "values",
       "data": ["zebra", "hedgehog", "llama", "flamingo"]
     },
-    "ACTIONS": {
+    "ACTIONS?sample=true": {
       "type": "values",
       "data": ["fling", "jump", "launch", "dispatch"]
     },
     "DOMAINS": {
       "type": "values",
-      "data": ["gmail.com", "yahoo.com", "hotmail.com"]
+      "data": {"gmail.com":  0.6, "yahoo.com": 0.3, "hotmail.com": 0.1}
     } 
   }
 }
@@ -70,18 +70,18 @@ Running dataspec from the command line against this spec:
 
 ```shell script
 dist/dataspec -s ~/example.json -i 12
-zebra_fling@gmail.com
-hedgehog_jump@yahoo.com
-llama_launch@hotmail.com
-flamingo_dispatch@gmail.com
-zebra_fling@yahoo.com
-hedgehog_jump@hotmail.com
-llama_launch@gmail.com
-flamingo_dispatch@yahoo.com
-zebra_fling@hotmail.com
-hedgehog_jump@gmail.com
+zebra_jump@gmail.com
+hedgehog_launch@yahoo.com
 llama_launch@yahoo.com
-flamingo_dispatch@hotmail.com
+flamingo_launch@gmail.com
+zebra_jump@hotmail.com
+hedgehog_jump@hotmail.com
+llama_dispatch@gmail.com
+flamingo_fling@yahoo.com
+zebra_fling@yahoo.com
+hedgehog_launch@gmail.com
+llama_jump@gmail.com
+flamingo_jump@gmail.com
 ```
 
 ### Field Specs
@@ -131,7 +131,6 @@ create or use one that solves many of your data generation issues.
 
 ```python
 import dataspec
-from dataspec import suppliers
 
 class ReverseStringSupplier:
     def __init__(self, wrapped):
@@ -149,7 +148,7 @@ def configure_supplier(field_spec, loader):
     # load the supplier for the given ref
     key = field_spec.get('ref')
     spec = loader.refs.get(key)
-    wrapped = suppliers.values(spec)
+    wrapped = loader.get_from_spec(spec)
     # wrap this with our custom reverse string supplier
     return ReverseStringSupplier(wrapped)
 ```

--- a/dataspec/loader.py
+++ b/dataspec/loader.py
@@ -22,16 +22,18 @@ class Loader:
     """
 
     def __init__(self, specs):
-        self.specs = specs
+        self.specs = _preprocess_spec(specs)
         self.cache = {}
         if 'refs' in specs:
-            self.refs = Refs(specs.get('refs'))
+            self.refs = Refs(self.specs.get('refs'))
         else:
             self.refs = None
 
     def get(self, key):
         """
         Retrieve the value supplier for the given field key
+
+        :param key: key to use, may have url format i.e. field_name?param=value...
         """
         if key in self.cache:
             return self.cache[key]
@@ -51,12 +53,56 @@ class Loader:
             spec_type = data_spec.get('type')
 
         if spec_type is None or spec_type == 'values':
-            return suppliers.values(data_spec)
+            supplier = suppliers.values(data_spec)
+        else:
+            handler = types.lookup_type(spec_type)
+            if handler is None:
+                raise SpecException('Unable to load handler for: ' + json.dumps(data_spec))
+            supplier = handler(data_spec, self)
 
-        handler = types.lookup_type(spec_type)
-        if handler is None:
-            raise SpecException('Unable to load handler for: ' + json.dumps(data_spec))
-        supplier = handler(data_spec, self)
         if suppliers.isdecorated(data_spec):
             return suppliers.decorated(data_spec, supplier)
         return supplier
+
+
+def _preprocess_spec(raw_spec):
+    """
+    Preprocesses the spec into a format that is easier to use.
+    Pushes all url params in keys into config object. Converts shorthand specs into full specs
+    :param raw_spec: to preprocess
+    :return: the reformatted spec
+    """
+    updated = {}
+    for key, spec in raw_spec.items():
+        if '?' not in key:
+            # check for conflicts
+            if key in updated:
+                raise SpecException(f'Field {key} defined multiple times: ' + json.dumps(spec))
+            updated[key] = spec
+        else:
+            if ' ' in key:
+                raise SpecException(f'Invalid url key {key}, no spaces allowed')
+            newkey, params = key.replace('?', ' ').split(' ', 2)
+            if newkey in updated:
+                raise SpecException(f'Field {key} defined multiple times: ' + json.dumps(spec))
+            if isinstance(spec, dict) and 'config' in spec:
+                config = spec['config']
+            else:
+                config = {}
+            for param in params.split('&'):
+                keyvalue = param.split('=')
+                config[keyvalue[0]] = keyvalue[1]
+
+            if isinstance(spec, dict) and 'data' in spec:
+                data = spec['data']
+            else:
+                data = spec
+
+            updated[newkey] = {
+                'type': 'values',
+                'data': data,
+                'config': config
+            }
+    if 'refs' in raw_spec:
+        updated['refs'] = _preprocess_spec(raw_spec['refs'])
+    return updated

--- a/dataspec/outputs.py
+++ b/dataspec/outputs.py
@@ -8,6 +8,7 @@ class SingleFieldOutput:
     """
     Writes each field as it is created
     """
+
     def __init__(self, writer, output_key):
         self.writer = writer
         self.output_key = output_key
@@ -26,6 +27,7 @@ class RecordLevelOutput:
     """
     Class to output after all fields have been generated
     """
+
     def __init__(self, record_processor, writer):
         """
         :param record_processor: turns the record into a string for writing
@@ -48,6 +50,7 @@ class StdOutWriter:
     """
     Writes values to stdout
     """
+
     def write(self, value):
         print(value)
 
@@ -56,6 +59,7 @@ class FileWriter:
     """
     Writes processed output to disk
     """
+
     def __init__(self, outdir, outname, extension=None, records_per_file=1):
         self.outdir = outdir
         self.outname = outname

--- a/dataspec/supplier/list_values.py
+++ b/dataspec/supplier/list_values.py
@@ -1,8 +1,14 @@
+import random
+
+
 class ListValueSupplier:
-    def __init__(self, data):
+    def __init__(self, data, do_sampling=False):
         self.values = data
+        self.do_sampling = do_sampling
 
     def next(self, iteration):
-        idx = iteration % len(self.values)
-        data = self.values[idx]
-        return data
+        if self.do_sampling:
+            return random.sample(self.values, 1)[0]
+        else:
+            idx = iteration % len(self.values)
+            return self.values[idx]

--- a/dataspec/type_handlers/range_handler.py
+++ b/dataspec/type_handlers/range_handler.py
@@ -23,7 +23,8 @@ def configure_supplier(field_spec, _):
 
     data = field_spec.get('data')
     if not isinstance(data, list) or len(data) < 2:
-        raise dataspec.SpecException('data element for ranges type must be list with at least two elements: %s' % json.dumps(field_spec))
+        raise dataspec.SpecException(
+            'data element for ranges type must be list with at least two elements: %s' % json.dumps(field_spec))
     start = data[0]
     # default for built in range function is exclusive end, we want to default to inclusive as this is the
     # more intuitive behavior
@@ -33,7 +34,7 @@ def configure_supplier(field_spec, _):
     if len(data) == 2:
         step = 1
     else:
-        step =  data[2]
+        step = data[2]
     if _any_is_float(data):
         range_values = list(float_range(float(start), float(end), float(step)))
     else:

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -2,7 +2,7 @@
 
 ## Generating Sentences to Train a Classifier On
 When training a Machine Learning Classifier, it can be difficult to create labeled data from scratch.  By analyzing the structure
-of the data it may be possible to augment the small initial set of examples by generating additional similar data that follows
+of the data it may be possible to augment a small initial set of examples by generating additional similar data that follows
 the same structure. For example, we want to create an Insult detector. Let's say these are the initial examples we have:
 
 ```

--- a/docs/FIELDSPECS.md
+++ b/docs/FIELDSPECS.md
@@ -13,7 +13,7 @@ Field Spec Definitions
 # Overview
 Each field that should be generated needs a specification that describes the way the values for it should be created. We
 refer to this as a Field Spec.  The simplest type of Field Spec is a values spec.  The main format of a values spec is a
-list of values to use.  These values are rotated through incrementally.  If the number of increments is larger than the
+list of values to use.  By default, these values are rotated through incrementally.  If the number of increments is larger than the
 number of values in the list, the values start over from the beginning of the list. When combining values from two values
 providers that are lists, they will be combined in incrementing order. i.e:
 
@@ -66,6 +66,7 @@ C3
 C4
 ```
 
+
 ## Field Spec Structure
 There are two types of Field Specs, one is the full format that is valid for all types, and the other is the shorthand
 for values types only.
@@ -103,6 +104,37 @@ and the same spec in shorthand notation.
   "field1": [1, 2, 3, 4, 5],
   "field2": {"A": 0.5, "B":  0.3, "C":  0.2},
   "field3": "CONSTANT"
+}
+```
+## Spec Configuration
+There are two ways to configure a spec.  One is by providing a `config` element in the Field Spec and the other is by using
+a URL parameter format in the key.  For example the following two specs will produce the same values:
+
+```json
+{
+  "ONE": {
+    "type": "values",
+    "data": [1, 2, 3],
+    "config": {"prefix":  "TEST", "suffix":  "@DEMO"}
+  },
+  "TWO?prefix=TEST&suffix=@DEMO": [1, 2, 3]
+}
+```
+
+## Sample Mode
+To increase the randomness of the data being generated you can configure a FieldSpec that contains a list of values to be
+sampled instead of iterated through incrementally. Normally the spec below would create the repeating sequence: `A1 B2 C3`,
+but since both fields `ONE` and `TWO` are in sample mode, we will get all nine combinations of values after a significant
+number of iterations. This would also be true if only one was set to sample mode. To turn sample mode on either use a URL
+param or config entry with one of `on`,  `yes`, or `true`. NOTE: Sample mode is only valid with entries that are lists.
+
+```json
+{
+  "combine": {"type": "combine", "refs":  ["ONE", "TWO"]},
+  "refs": {
+    "ONE?sample=true":["A", "B", "C"],
+    "TWO?sample=true":[1, 2, 3]
+  }
 }
 ```
 

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -1,5 +1,8 @@
 import dataspec.suppliers as suppliers
+from dataspec.loader import _preprocess_spec
+from dataspec.exceptions import SpecException
 from collections import Counter
+import pytest
 
 
 def test_single_value():
@@ -53,3 +56,12 @@ def test_shortcut_notation():
 
     assert 'foo' in most_common_keys
     assert 'bar' in most_common_keys
+
+
+def test_sampling_mode_invalid_for_weighted_values():
+    spec = {
+        'foo?sample=True': {10: 0.5, 20: 0.3, 30: 0.2}
+    }
+    updated = _preprocess_spec(spec)
+    with pytest.raises(SpecException):
+        suppliers.values(updated['foo'])


### PR DESCRIPTION
To allow simpler configuration now the keys of DataSpec can have the form:
field_name?param1=val1&param2=val2...

This is equivalent of putting the key values into the config element

Added new config param sample for list values. This allows
a list to be sampled instead of iterated through

Updated documentation with new examples for new features